### PR TITLE
Defense teamstats summary no table found fix

### DIFF
--- a/kenpompy/summary.py
+++ b/kenpompy/summary.py
@@ -147,7 +147,7 @@ def get_teamstats(browser, defense=False, season=None):
 			url = url + '&od=d'
 			last_cols = ['AdjDE', 'AdjDE.Rank']
 	elif defense:
-		url = url + '&od=d'
+		url = url + '?od=d'
 		last_cols = ['AdjDE', 'AdjDE.Rank']
 
 	browser.open(url)


### PR DESCRIPTION
Fix to be able to grab defense summary team stats without a season.