### PR TITLE
Fixes j-andrews7/kenpompy#12

### DIFF
--- a/kenpompy/summary.py
+++ b/kenpompy/summary.py
@@ -147,7 +147,7 @@ def get_teamstats(browser, defense=False, season=None):
 			url = url + '&od=d'
 			last_cols = ['AdjDE', 'AdjDE.Rank']
 	elif defense:
-		url = url + '&od=d'
+		url = url + '?od=d'
 		last_cols = ['AdjDE', 'AdjDE.Rank']
 
 	browser.open(url)


### PR DESCRIPTION
This branch provides a fix for the typo in the URL building logic described in j-andrews7/kenpompy#12 by changing the ampersand `&` delimiter to a question mark `?` delimiter (to properly denotate the beginning of the URL parameters within the aforementioned generated URL).