### PR TITLE
Enhancement: Add login failure detection

### DIFF
--- a/kenpompy/utils.py
+++ b/kenpompy/utils.py
@@ -29,7 +29,7 @@ def login(email, password):
 
 	response = browser.submit_selected()
 
-	if response.status_code != 200:
+	if response.status_code != 200 or 'PHPSESSID=' not in response.headers['set-cookie']:
 		raise Exception(
 			'Logging in to kenpom.com failed - check that the site is available and your credentials are correct.')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,5 +4,9 @@ from kenpompy.utils import login
 
 @pytest.fixture(scope="session")
 def browser():
-	bowser = login(os.environ["EMAIL"], os.environ["PASSWORD"])
-	return bowser
+	try:
+		browser = login(os.environ["EMAIL"], os.environ["PASSWORD"])
+	except Exception as e:
+		pytest.exit(e)
+
+	return browser


### PR DESCRIPTION
Logging into KenPom with MechanicalSoup is a bit wonky in that the service seems to always return `200 OK` status code even on a credential-related failure. This leads to confusion like in #15 where one might assume a login was successful as no exception was thrown, but downstream encounters issues trying to pull data requiring a valid session.

On further inspection, it seems the difference the response for a successful login and an unsuccessful one (due to incorrect credentials) is that the `Set-Cookie` response header returns a `PHPSESSID` for successful logins, and cookie invalidation information otherwise. As such, I've updated `utils.py` to look for the string `"PHPSESSID="` in the response header value for `Set-Cookie` and, in its absence, throw the `Logging in to kenpom.com failed` Exception. I've also added logic into `tests/conftest.py` to ensure that `pytest` aborts when the login fails (as most tests will begin failing without a successful login anyway).

If you can, I could use some help testing this in verifying that everyone does indeed get a `Set-Cookie: "PHPSESSID=..."` header on successful login before this gets merged in.