### PR TITLE
Fix for ambiguous column names in DataFrame returned by get_pomeroy_ratings

### DIFF
--- a/kenpompy/misc.py
+++ b/kenpompy/misc.py
@@ -39,6 +39,10 @@ def get_pomeroy_ratings(browser, season=None):
     tmp = ratings_df['Team'].str.extract(r'(?P<Team>[a-zA-Z.&\'\s]+(?<!\s))\s*(?P<Seed>\d*)')
     ratings_df["Team"] = tmp["Team"]
     ratings_df["Seed"] = tmp["Seed"]
+    ratings_df.columns = ['Rk', 'Team', 'Conf', 'W-L', 'AdjEM', 'AdjO',
+                          'AdjO.Rank', 'AdjD', 'AdjD.Rank', 'AdjT', 'AdjT.Rank',
+						  'Luck', 'Luck.Rank', 'SOS-AdjEM', 'SOS-AdjEM.Rank', 'SOS-OppO', 'SOS-OppO.Rank',
+						  'SOS-OppD', 'SOS-OppD.Rank', 'NCSOS-AdjEM', 'NCSOS-AdjEM.Rank', 'Seed']
     return ratings_df
 
 

--- a/kenpompy/misc.py
+++ b/kenpompy/misc.py
@@ -34,6 +34,7 @@ def get_pomeroy_ratings(browser, season=None):
     ratings_df.columns = ratings_df.columns.map(lambda x: x[1])
     ratings_df.dropna(inplace=True)
     ratings_df = ratings_df[ratings_df["Rk"] != "Rk"]
+    ratings_df.reset_index(drop=True, inplace=True)
     # Parse out seed, most current won't have this
     tmp = ratings_df['Team'].str.extract(r'(?P<Team>[a-zA-Z.&\'\s]+(?<!\s))\s*(?P<Seed>\d*)')
     ratings_df["Team"] = tmp["Team"]

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -12,6 +12,10 @@ def test_get_pomeroy_ratings(browser):
     expected = ['31', "Saint Mary's", 'WCC', '22-12', '+17.31', '114.7', '23', '97.4', '55', '62.7', '348', '-.045', '285', '+3.66', '82', '106.6', '76', '103.0', '100', '-0.90', '183', '11']
     assert df.iloc[30].to_list() == expected
 
+	# Shape test to ensure header rows are correctly filtered
+    expected = (353, 22)
+    assert df.shape == expected
+
 def test_get_trends(browser):
 	expected = ["2019","103.2","69.0","50.7","18.5","28.4","33.0","50.1","34.4","38.7","70.7","51.9","9.3","8.9","9.7",
 				"76.8","47.8","59.0","71.9"]


### PR DESCRIPTION
Currently, the DataFrame returned by `kenpompy.misc.get_pomeroy_ratings()` has several columns which share the same name. Needless to say, this can make it difficult to parse which column refers to which specific piece of data at first glance, and difficult to reference the specific column one might be after.

This PR introduces explicitly-prescribed column names to the returned DataFrame to alleviate this.

@j-andrews7 Wanted to run this change by you and get your thoughts before merging into the working branch, since it's a potentially breaking change.