### PR TITLE
Fix for Cloudflare SSL profiling

### DIFF
--- a/kenpompy/_DESAdapter.py
+++ b/kenpompy/_DESAdapter.py
@@ -1,0 +1,26 @@
+from sys import version_info
+from requests.adapters import HTTPAdapter
+from urllib3.util.ssl_ import create_urllib3_context
+
+CIPHERS = (
+    ':@SECLEVEL=2:ECDH+AESGCM:ECDH+CHACHA20:ECDH+AES:DHE+AES:!aNULL:!eNULL:!aDSS:!SHA1:!AESCCM'
+)
+
+def environment_requires_DES_adapter():
+    return version_info.major == 3 and version_info.minor < 11
+
+class DESAdapter(HTTPAdapter):
+    """
+    A TransportAdapter that re-enables 3DES support in Requests to avoid Cloudflare filtering based on SSL profiling
+    Adapted from the research provided by Nick Ostendorf (@nickostendorf) in https://github.com/j-andrews7/kenpompy/issues/33
+    """
+
+    def init_poolmanager(self, *args, **kwargs):
+        context = create_urllib3_context(ciphers=CIPHERS)
+        kwargs['ssl_context'] = context
+        return super(DESAdapter, self).init_poolmanager(*args, **kwargs)
+
+    def proxy_manager_for(self, *args, **kwargs):
+        context = create_urllib3_context(ciphers=CIPHERS)
+        kwargs['ssl_context'] = context
+        return super(DESAdapter, self).proxy_manager_for(*args, **kwargs)

--- a/kenpompy/utils.py
+++ b/kenpompy/utils.py
@@ -5,7 +5,7 @@ The utils module provides utility functions, such as logging in.
 import mechanicalsoup
 from bs4 import BeautifulSoup
 from requests import Session
-from _DESAdapter import DESAdapter, environment_requires_DES_adapter
+from ._DESAdapter import DESAdapter, environment_requires_DES_adapter
 
 def login(email, password):
 	"""

--- a/kenpompy/utils.py
+++ b/kenpompy/utils.py
@@ -4,6 +4,8 @@ The utils module provides utility functions, such as logging in.
 
 import mechanicalsoup
 from bs4 import BeautifulSoup
+from requests import Session
+from _DESAdapter import DESAdapter, environment_requires_DES_adapter
 
 def login(email, password):
 	"""
@@ -17,7 +19,12 @@ def login(email, password):
 		browser (mechanicalsoup StatefulBrowser): Authenticated browser with full access to kenpom.com.
 	"""
 
-	browser = mechanicalsoup.StatefulBrowser()
+	# Fix for Cloudflare SSL profiling (https://github.com/j-andrews7/kenpompy/issues/33) provided by Nick Ostendorf (@nickostendorf)
+	session = Session()
+	if environment_requires_DES_adapter():
+		session.mount('https://kenpom.com/', DESAdapter())
+
+	browser = mechanicalsoup.StatefulBrowser(session)
 	browser.set_user_agent('Mozilla/5.0')
 	browser.open('https://kenpom.com/index.php')
 


### PR DESCRIPTION
Hi @j-andrews7 - this PR is to merge the identified fix relating to the TLS fingerprinting it seems was likely the culprit behind the sporadic reports of Cloudflare filtering requests made by the library to KenPom.com (#33).

The fix included in this PR re-enables the `DES` cipher, which seems to make our requests look much nicer to Cloudflare in environments running Python <3.11.x.

A big thanks to @nickostendorf whose research provided yesterday was ultimately able to identify this as the likely core issue.