### PR TITLE
Enhancement: Team Stats table

### DIFF
--- a/kenpompy/FanMatch.py
+++ b/kenpompy/FanMatch.py
@@ -5,7 +5,6 @@ This module contains the FanMatch class for scraping the FanMatch pages into mor
 import mechanicalsoup
 import pandas as pd
 from bs4 import BeautifulSoup
-import re
 
 class FanMatch:
     """Object to hold FanMatch page scraping results.
@@ -46,7 +45,6 @@ class FanMatch:
         self.record_favs = None
         self.expected_record_favs = None
         self.exact_mov = None
-        self.conf_tourneys = ['Amer-T', 'P12-T', 'SEC-T', 'BE-T', 'B10-T', 'B12-T', 'WCC-T', 'MWC-T', 'CUSA-T', 'ACC-T', 'Conf-T', 'ASun-T', 'Sum-T', 'WAC-T', 'Ivy-T', 'CAA-T', 'A10-T', 'MAAC-T', 'MAC-T', 'MVC-T', 'SB-T', 'SC-T', 'BW-T', 'BSky-T', 'Pat-T', 'Horz-T', 'AE-T', 'BSth-T', 'Slnd-T', 'SWAC-T', 'MEAC-T', 'OVC-T']
         
         if self.date is not None:
             self.url = self.url + "?d=" + self.date
@@ -61,10 +59,6 @@ class FanMatch:
         fm_df["ThrillScoreRank"] = fm_df.ThrillScore.str[4:]
         fm_df["ThrillScoreRank"] = fm_df["ThrillScoreRank"].str.strip()
         fm_df.ThrillScore = fm_df.ThrillScore.str[0:4]
-        
-        # Remove Conf. Tourneys
-        p = re.compile('|'.join(map(re.escape, self.conf_tourneys)))
-        fm_df['Game'] = [p.sub('', text) for text in fm_df['Game']] 
 
         # Take care of parsing if some/all games have been completed.
         if not all(pd.isnull(fm_df["Excitement"])):

--- a/kenpompy/FanMatch.py
+++ b/kenpompy/FanMatch.py
@@ -5,6 +5,7 @@ This module contains the FanMatch class for scraping the FanMatch pages into mor
 import mechanicalsoup
 import pandas as pd
 from bs4 import BeautifulSoup
+import re
 
 class FanMatch:
     """Object to hold FanMatch page scraping results.
@@ -45,6 +46,7 @@ class FanMatch:
         self.record_favs = None
         self.expected_record_favs = None
         self.exact_mov = None
+        self.conf_tourneys = ['Amer-T', 'P12-T', 'SEC-T', 'BE-T', 'B10-T', 'B12-T', 'WCC-T', 'MWC-T', 'CUSA-T', 'ACC-T', 'Conf-T', 'ASun-T', 'Sum-T', 'WAC-T', 'Ivy-T', 'CAA-T', 'A10-T', 'MAAC-T', 'MAC-T', 'MVC-T', 'SB-T', 'SC-T', 'BW-T', 'BSky-T', 'Pat-T', 'Horz-T', 'AE-T', 'BSth-T', 'Slnd-T', 'SWAC-T', 'MEAC-T', 'OVC-T']
         
         if self.date is not None:
             self.url = self.url + "?d=" + self.date
@@ -60,6 +62,10 @@ class FanMatch:
         fm_df["ThrillScoreRank"] = fm_df["ThrillScoreRank"].str.strip()
         fm_df.ThrillScore = fm_df.ThrillScore.str[0:4]
         
+        # Remove Conf. Tourneys
+        p = re.compile('|'.join(map(re.escape, self.conf_tourneys)))
+        fm_df['Game'] = [p.sub('', text) for text in fm_df['Game']] 
+
         # Take care of parsing if some/all games have been completed.
         if not all(pd.isnull(fm_df["Excitement"])):
             fm_df["Excitement"] = fm_df.Excitement.str.split("·").str[0]

--- a/kenpompy/team.py
+++ b/kenpompy/team.py
@@ -8,6 +8,10 @@ import pandas as pd
 import re
 from bs4 import BeautifulSoup
 import datetime
+import tempfile
+
+from requests_html import HTMLSession
+from requests_file import FileAdapter
 
 
 def get_valid_teams(browser, season=None):
@@ -102,3 +106,81 @@ def get_schedule(browser, team=None, season=None):
 	schedule_df = schedule_df.fillna('')
 
 	return schedule_df
+
+def get_stats(browser, team=None, season=None):
+    """
+    Scrapes a team's stats from (https://kenpom.com/team.php) into a dataframe.
+
+    Args:
+        browser (mechanicalsoul StatefulBrowser): Authenticated browser with full access to kenpom.com generated
+            by the `login` function
+        team: Used to determine which team to scrape for schedule.
+        season (str, optional): Used to define different seasons. 2002 is the earliest available season.
+
+    Returns:
+        stats_df (pandas dataframe): Dataframe containing a team's schedule for the given season.
+
+    Raises:
+        ValueError if `season` is less than 2002.
+        ValueError if `season` is greater than the current year.
+        ValueError if `team` is not in the valid team list.
+    """
+
+    url = 'https://kenpom.com/team.php'
+
+    date = datetime.date.today()
+    currentYear = date.strftime("%Y")
+
+    if season:
+        if int(season) < 2002:
+            raise ValueError(
+                'season cannot be less than 2002, as data only goes back that far.')
+        if int(season) > int(currentYear):
+            raise ValueError(
+                'season cannot be greater than the current year.')
+    else:
+        season = int(currentYear)
+
+    if team == None or team not in get_valid_teams(browser, season):
+            raise ValueError(
+                'the team does not exist in kenpom in the given year.  Check that the spelling matches (https://kenpom.com) exactly.')
+
+    # Sanitize team name
+    team = team.replace(" ", "+")
+    team = team.replace("&", "%26")
+    url = url + "?team=" + str(team)
+    url = url + "&y=" + str(season)
+
+    browser.open(url)
+    team_page = browser.get_current_page()
+
+    # Save page to temporarily
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.html') as file:
+        file.write(team_page.encode())
+
+    # Open requests_html session with saved paged
+    """
+	While using requests_html and request_file
+	we are able to render the javascript on teams page
+	that mechanicalSoup is unable to do.
+	"""
+    sess = HTMLSession()
+    sess.mount('file://', FileAdapter())
+    r = sess.get(f'file:///{file.name}')
+    r.html.render()
+
+	# Create soup object from rendered page
+    soup = BeautifulSoup(r.html.html, 'html.parser')
+
+	# Retrieve stats table and parse into DataFrame
+    statsTable = soup.findAll('table')[0]
+    stats_df = pd.read_html(str(statsTable))[0]
+
+    # DataFrame cleaning, drop repeated column names
+    stats_df.drop([3,8,15,18,22,26], inplace=True)
+
+    # Remove stat rankings
+    stats_df['Offense'] = stats_df['Offense'].str.split().str[0]
+    stats_df['Defense'] = stats_df['Defense'].str.split().str[0]
+
+    return stats_df

--- a/kenpompy/team.py
+++ b/kenpompy/team.py
@@ -112,7 +112,7 @@ async def get_stats(browser, team=None, season=None, _async=False):
 	Scrapes a team's stats from (https://kenpom.com/team.php) into a dataframe.
 
 	Args:
-		browser (mechanicalsoul StatefulBrowser): Authenticated browser with full access to kenpom.com generated
+		browser (mechanicalsoup StatefulBrowser): Authenticated browser with full access to kenpom.com generated
 			by the `login` function
 		team: Used to determine which team to scrape for stats.
 		season (str, optional): Used to define different seasons. 2002 is the earliest available season.
@@ -191,8 +191,10 @@ async def get_stats(browser, team=None, season=None, _async=False):
 	# DataFrame cleaning, drop repeated column names
 	stats_df.drop([3, 8, 15, 18, 22, 26], inplace=True)
 
-	# Remove stat rankings
+	# Split Off/Def stats and rankings into their own columns
+	stats_df['OffenseRank'] = stats_df['Offense'].str.split().str[1]
 	stats_df['Offense'] = stats_df['Offense'].str.split().str[0]
+	stats_df['DefenseRank'] = stats_df['Defense'].str.split().str[1]
 	stats_df['Defense'] = stats_df['Defense'].str.split().str[0]
 
 	return stats_df

--- a/kenpompy/team.py
+++ b/kenpompy/team.py
@@ -36,7 +36,7 @@ def get_valid_teams(browser, season=None):
 	team_df = pd.read_html(str(table))
 	# Get only the team column.
 	team_df = team_df[0].iloc[:, 1]
- 	# Remove NCAA tourny seeds for previous seasons.
+	 # Remove NCAA tourny seeds for previous seasons.
 	team_df = team_df.str.replace(r'\d+', '', regex=True)
 	team_df = team_df.str.rstrip()
 	team_df = team_df.dropna()
@@ -45,8 +45,6 @@ def get_valid_teams(browser, season=None):
 	team_list = [team for team in team_df if team != "Team"]
 
 	return team_list
-
-
 
 
 def get_schedule(browser, team=None, season=None):
@@ -83,10 +81,10 @@ def get_schedule(browser, team=None, season=None):
 	else:
 		season = int(currentYear)
 
-	if team==None or team not in get_valid_teams(browser, season):
-			raise ValueError(
-				'the team does not exist in kenpom in the given year.  Check that the spelling matches (https://kenpom.com) exactly.')
-	
+	if team == None or team not in get_valid_teams(browser, season):
+		raise ValueError(
+			'the team does not exist in kenpom in the given year.  Check that the spelling matches (https://kenpom.com) exactly.')
+
 	# Sanitize team name
 	team = team.replace(" ", "+")
 	team = team.replace("&", "%26")
@@ -101,86 +99,87 @@ def get_schedule(browser, team=None, season=None):
 	# Dataframe Tidying
 	schedule_df = schedule_df[0]
 	schedule_df.columns = ['Date', 'Team Rank', 'Opponent Rank', 'Opponent Name', 'Result', 'Possession Number',
-					  'A', 'Location', 'Record', 'Conference', 'B']
-	schedule_df = schedule_df.drop(columns = ['A', 'B'])
+						'A', 'Location', 'Record', 'Conference', 'B']
+	schedule_df = schedule_df.drop(columns=['A', 'B'])
 	schedule_df = schedule_df.fillna('')
 
 	return schedule_df
 
+
 def get_stats(browser, team=None, season=None):
-    """
-    Scrapes a team's stats from (https://kenpom.com/team.php) into a dataframe.
+	"""
+	Scrapes a team's stats from (https://kenpom.com/team.php) into a dataframe.
 
-    Args:
-        browser (mechanicalsoul StatefulBrowser): Authenticated browser with full access to kenpom.com generated
-            by the `login` function
-        team: Used to determine which team to scrape for schedule.
-        season (str, optional): Used to define different seasons. 2002 is the earliest available season.
+	Args:
+		browser (mechanicalsoul StatefulBrowser): Authenticated browser with full access to kenpom.com generated
+			by the `login` function
+		team: Used to determine which team to scrape for stats.
+		season (str, optional): Used to define different seasons. 2002 is the earliest available season.
 
-    Returns:
-        stats_df (pandas dataframe): Dataframe containing a team's schedule for the given season.
+	Returns:
+		stats_df (pandas dataframe): Dataframe containing a team's stats for the given season.
 
-    Raises:
-        ValueError if `season` is less than 2002.
-        ValueError if `season` is greater than the current year.
-        ValueError if `team` is not in the valid team list.
-    """
+	Raises:
+		ValueError if `season` is less than 2002.
+		ValueError if `season` is greater than the current year.
+		ValueError if `team` is not in the valid team list.
+	"""
 
-    url = 'https://kenpom.com/team.php'
+	url = 'https://kenpom.com/team.php'
 
-    date = datetime.date.today()
-    currentYear = date.strftime("%Y")
+	date = datetime.date.today()
+	currentYear = date.strftime("%Y")
 
-    if season:
-        if int(season) < 2002:
-            raise ValueError(
-                'season cannot be less than 2002, as data only goes back that far.')
-        if int(season) > int(currentYear):
-            raise ValueError(
-                'season cannot be greater than the current year.')
-    else:
-        season = int(currentYear)
+	if season:
+		if int(season) < 2002:
+			raise ValueError(
+				'season cannot be less than 2002, as data only goes back that far.')
+		if int(season) > int(currentYear):
+			raise ValueError(
+				'season cannot be greater than the current year.')
+	else:
+		season = int(currentYear)
 
-    if team == None or team not in get_valid_teams(browser, season):
-            raise ValueError(
-                'the team does not exist in kenpom in the given year.  Check that the spelling matches (https://kenpom.com) exactly.')
+	if team == None or team not in get_valid_teams(browser, season):
+		raise ValueError(
+			'the team does not exist in kenpom in the given year.  Check that the spelling matches (https://kenpom.com) exactly.')
 
-    # Sanitize team name
-    team = team.replace(" ", "+")
-    team = team.replace("&", "%26")
-    url = url + "?team=" + str(team)
-    url = url + "&y=" + str(season)
+	# Sanitize team name
+	team = team.replace(" ", "+")
+	team = team.replace("&", "%26")
+	url = url + "?team=" + str(team)
+	url = url + "&y=" + str(season)
 
-    browser.open(url)
-    team_page = browser.get_current_page()
+	browser.open(url)
+	team_page = browser.get_current_page()
 
-    # Save page to temporarily
-    with tempfile.NamedTemporaryFile(delete=False, suffix='.html') as file:
-        file.write(team_page.encode())
+	# Save page to temporarily
+	with tempfile.NamedTemporaryFile(delete=False, suffix='.html') as file:
+		file.write(team_page.encode())
 
-    # Open requests_html session with saved paged
-    """
+	# Open saved paged with requests_html session
+	"""
 	While using requests_html and request_file
 	we are able to render the javascript on teams page
 	that mechanicalSoup is unable to do.
 	"""
-    sess = HTMLSession()
-    sess.mount('file://', FileAdapter())
-    r = sess.get(f'file:///{file.name}')
-    r.html.render()
+	sess = HTMLSession()
+	sess.mount('file://', FileAdapter())
+	r = sess.get(f'file:///{file.name}')
+	r.html.render()
 
 	# Create soup object from rendered page
-    soup = BeautifulSoup(r.html.html, 'html.parser')
+	soup = BeautifulSoup(r.html.html, 'html.parser')
 
 	# Retrieve stats table and parse into DataFrame
-    statsTable = soup.findAll('table')[0]
-    stats_df = pd.read_html(str(statsTable))[0]
+	statsTable = soup.findAll('table')[0]
+	stats_df = pd.read_html(str(statsTable))[0]
 
-    # DataFrame cleaning, drop repeated column names
-    stats_df.drop([3,8,15,18,22,26], inplace=True)
+	# DataFrame cleaning, drop repeated column names
+	stats_df.drop([3, 8, 15, 18, 22, 26], inplace=True)
 
-    # Remove stat rankings
-    stats_df['Offense'] = stats_df['Offense'].str.split().str[0]
-    stats_df['Defense'] = stats_df['Defense'].str.split().str[0]
+	# Remove stat rankings
+	stats_df['Offense'] = stats_df['Offense'].str.split().str[0]
+	stats_df['Defense'] = stats_df['Defense'].str.split().str[0]
 
-    return stats_df
+	return stats_df

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ mechanicalsoup
 pandas
 bs4
 sphinx>2.2.0
+requests-file==1.5.1
+requests-html==0.10.0

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,6 @@ setuptools.setup(
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers"
     ],
-    install_requires = ["mechanicalsoup", "pandas", "bs4"],
+    install_requires = ["mechanicalsoup", "pandas", "bs4", "requests_html", "requests_file"],
     python_requires='>=3.8',
 )

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -51,3 +51,28 @@ def test_get_schedule(browser):
 	# Make sure that the valid team check is triggered
 	with pytest.raises(ValueError):
 		kpteam.get_schedule(browser, season = '2013', team="LMU")
+
+def test_get_stats(browser):
+	expectedAdjEff = ['Adj. Efficiency', '124.5', '91.6', '104.3']
+	expectedFT = ['Free Throws:', '18.6', '17.0', '18.7']
+
+	df = kpteam.get_stats(browser, team="Gonzaga", season = '2019')
+	assert [str(i) for i in df[df.Category == 'Adj. Efficiency'].iloc[0].to_list()] == expectedAdjEff
+	assert [str(i) for i in df[df.Category == 'Free Throws:'].iloc[0].to_list()] == expectedFT
+    
+	date = datetime.date.today()
+	currentYear = date.strftime("%Y")
+	nextYear = str(int(currentYear)+1)
+
+	with pytest.raises(ValueError):
+		kpteam.get_stats(browser, team="Iowa", season = '2001')
+
+	with pytest.raises(ValueError):
+		kpteam.get_stats(browser, team="Kansas", season = nextYear)
+
+	with pytest.raises(ValueError):
+		kpteam.get_stats(browser, season = "2009")
+
+	# Make sure that the valid team check is triggered
+	with pytest.raises(ValueError):
+		kpteam.get_stats(browser, season = '2013', team="LMU")


### PR DESCRIPTION
The current team module only pulls valid teams and team schedules.
This PR allows retrieving of a team's stats similar to pulling their schedule.

Kenpom's team pages uses javascript to fill the majority of the 'Scouting Report' table. 
Therefore, these values are not available to `MechanicalSoup` since MechanicalSoup is only an HTML parser.

I used two packages to help with the extraction:
- `requests_html`
- `requests_file`

## Walkthrough

Open page as normal
```
browser.open(url)
team_page = browser.get_current_page()
```
Save page temporarily so that we can make a request to it using `requests_html`
```
# Save page to temporarily
with tempfile.NamedTemporaryFile(delete=False, suffix='.html') as file:
    file.write(team_page.encode())
```
Open saved paged with `requests_html` session 
We use `requests_file`'s `FileAdapter` to allow `requests_html` to open local files.
The render() function opens the session in a headless chromium browser.
Then it returns the html with javascript executed.
```
sess = HTMLSession()
sess.mount('file://', FileAdapter())
r = sess.get(f'file:///{file.name}')
r.html.render()
```
Create a new `BeautifulSoup` object from rendered html and find stats table
```
# Create soup object from rendered page
soup = BeautifulSoup(r.html.html, 'html.parser')

# Retrieve stats table and parse into DataFrame
statsTable = soup.findAll('table')[0]
stats_df = pd.read_html(str(statsTable))[0]
```

The first time `render()` is called on a system, it will download a chromium binary (~85mb)
I didn't like the idea of making a user download a whole browser binary just for a table. 
However, this route is still quicker and lighter than going with a `selenium` approach.
I also believe this `requests_html` approach can be used to retrieve more missing data around Kenpom.

I have added a couple tests in `test_team.py`.
Please let me know if anyone has any questions.

Thanks!