### PR TITLE
Added check for expired subscription (closes #37)

### DIFF
--- a/kenpompy/utils.py
+++ b/kenpompy/utils.py
@@ -43,5 +43,9 @@ def login(email, password):
 	if response.status_code != 200 or 'PHPSESSID=' not in response.headers['set-cookie']:
 		raise Exception(
 			'Logging in to kenpom.com failed - check that the site is available and your credentials are correct.')
+	
+	if 'subscription expired' in str(browser.get('https://kenpom.com/index.php').content):
+		raise Exception(
+			'Logging in to kenpom.com failed - account subscription is expired')
 
 	return browser


### PR DESCRIPTION
Added an additional `GET` to `/index.php` in `login()` to ascertain whether or not the logged-in account has an expired subscription.

Creating this PR for transparency & to give @j-andrews7 an opportunity to opine on whether the introduction of an additional request in this method is acceptable overhead.