### PR TITLE
Fixed parsing for tournament labels on FanMatch pages (fixes #47)

### DIFF
--- a/kenpompy/FanMatch.py
+++ b/kenpompy/FanMatch.py
@@ -106,6 +106,10 @@ class FanMatch:
         mvp = fm_df.Game.str.split(" MVP: ").str[1]
         fm_df["Game"], fm_df["MVP"] = fm_df.Game.str.split(" MVP: ").str[0], mvp
 
+        # Conference tournament label handling (fixes j-andrews7/kenpompy#47)
+        fm_df["Tournament"] = fm_df.Game.str.extract(r"([A-Za-z]{2,}-T|NCAA)$")
+        fm_df["Game"] = fm_df.Game.str.replace(r"(\s+[A-Za-z]{2,}-T|NCAA)$", "", regex=True)
+
         pos = fm_df.Game.str.split(r" \[").str[1]
         fm_df["Game"], fm_df["Possessions"] = fm_df.Game.str.split(r" \[").str[0], pos.astype("str")
         fm_df.Possessions = fm_df.Possessions.str.strip(r"\]")

--- a/kenpompy/FanMatch.py
+++ b/kenpompy/FanMatch.py
@@ -112,7 +112,7 @@ class FanMatch:
 
         pos = fm_df.Game.str.split(r" \[").str[1]
         fm_df["Game"], fm_df["Possessions"] = fm_df.Game.str.split(r" \[").str[0], pos.astype("str")
-        fm_df.Possessions = fm_df.Possessions.str.strip(r"\]")
+        fm_df.Possessions = fm_df.Possessions.str.rstrip(r"\] ")
         predict_info = fm_df.Prediction.str.split()
         pred_winner = fm_df.Prediction.astype("str").str.split().str[0:-2].tolist()
         pred_winner = [" ".join(i) if not any(pd.isnull(i)) else float("nan") for i in pred_winner]

--- a/tests/test_fanmatch.py
+++ b/tests/test_fanmatch.py
@@ -15,6 +15,7 @@ def test_fanmatch(browser):
 				"nan",
 				"nan",
 				"Sacar Anim (28p/5r/2a/1b/4s)",
+				"nan",
 				"79",
 				"Marquette",
 				"73-72",
@@ -46,3 +47,14 @@ def test_fanmatch(browser):
 	assert fm.record_favs == "40-13"
 	assert fm.expected_record_favs == "38-15"
 	assert fm.exact_mov == "1/53"
+
+	# Tests for tournament label parsing (j-andrews7/kenpompy#47)
+	date = "2023-03-03"
+	fm = FanMatch(browser, date)
+	assert "MVC-T" not in fm.fm_df.Game.loc[3]
+	assert fm.fm_df.Tournament.loc[6] == "WCC-T"
+
+	date = "2016-04-02"
+	fm = FanMatch(browser, date)
+	assert fm.fm_df.Tournament.loc[0] == "NCAA"
+	assert "NCAA" not in fm.fm_df.Game.loc[0]


### PR DESCRIPTION
Added some logic to parse any conference/NCAA tournament labels from the FanMatch `fm_df.Game` field to a dedicated `Tournament` column and subsequently remove them from the `Game` field. Includes the associated tests as well.