### PR TITLE
Enhancement: Conference stats

### DIFF
--- a/kenpompy/conference.py
+++ b/kenpompy/conference.py
@@ -1,5 +1,5 @@
 """
-This module contains functions for scraping the confernce page kenpom.com tables into
+This module contains functions for scraping the conference page kenpom.com tables into
 pandas dataframes
 """
 

--- a/kenpompy/conference.py
+++ b/kenpompy/conference.py
@@ -1,5 +1,5 @@
 """
-This module contains functions for scraping the team page kenpom.com tables into
+This module contains functions for scraping the confernce page kenpom.com tables into
 pandas dataframes
 """
 
@@ -12,7 +12,7 @@ import datetime
 
 def get_valid_conferences(browser, season=None):
 	"""
-	Scrapes the conferences (https://kenpom.com) into a list.
+	Scrapes the conferences (https://kenpom.com/conf.php) into a list.
 
 	Args:
 		browser (mechanicalsoul StatefulBrowser): Authenticated browser with full access to kenpom.com generated
@@ -34,48 +34,61 @@ def get_valid_conferences(browser, season=None):
 	conf_list = []
 	for link in links:
 		conf_list.append(link['href'].split('=')[-1])
-	
+	conf_list.sort()
 	return conf_list
 
-def get_aggregate_stats(browser, conf, season=None):
+
+def get_aggregate_stats(browser, conf=None, season=None):
 	"""
-	Scrapes a given conference's stats (https://kenpom.com) into a dataframe.
+	Scrapes a given conference's stats (https://kenpom.com/conf.php or https://kenpom.com/confstats.php) into a dataframe.
 
 	Args:
 		browser (mechanicalsoul StatefulBrowser): Authenticated browser with full access to kenpom.com generated
 			by the `login` function
-		conf (str): conference abbreviation (ie B10, P12)
+		conf (str: optional): conference abbreviation (ie B10, P12). If None, it will grab the table from https://kenpom.com/confstats.php instead of https://kenpom.com/conf.php
 		season (str, optional): Used to define different seasons. 2002 is the earliest available season.
 
 	Returns:
 		conference_df (dataframe): Dataframe containing aggregate stats of the conference for the given season on kenpom.com.
 	"""
-
-	url = "https://kenpom.com/conf.php"
-	url = url + f'?c={conf}'
-	if(season):
-		url = url + '&y=' + str(season)
-	browser.open(url)
-	confs = browser.get_current_page()
-	#get first table
-	table = confs.find_all('table')[-3]
-	conf_df = pd.read_html(str(table))[0]
-	#get second table
-	table = confs.find_all('table')[-2]
-	conf2_df = pd.read_html(str(table))[0]
-	conf2_df['Value'] = conf2_df['Value'].str.replace('%', '').astype(float)
-	conf_df = pd.concat([conf_df, conf2_df])
-	#clean table
-	conf_df = conf_df.set_index('Stat')
-	conf_df = conf_df.drop('Unnamed: 1', axis=1)
-	conf_df.columns = ['Value', 'Rank']
-	conf_df.index = conf_df.index.str.split(' (', regex=False).str[0]
-	print(conf_df)
-	return conf_df
+	if(conf):
+		url = "https://kenpom.com/conf.php"
+		url = url + f'?c={conf}'
+		if(season):
+			url = url + '&y=' + str(season)
+		browser.open(url)
+		confs = browser.get_current_page()
+		#get first table
+		table = confs.find_all('table')[-3]
+		conf_df = pd.read_html(str(table))[0]
+		#get second table
+		table = confs.find_all('table')[-2]
+		conf2_df = pd.read_html(str(table))[0]
+		conf2_df['Value'] = conf2_df['Value'].str.replace('%', '').astype(float)
+		conf_df = pd.concat([conf_df, conf2_df])
+		#clean table
+		conf_df = conf_df.set_index('Stat')
+		conf_df = conf_df.drop('Unnamed: 1', axis=1)
+		conf_df.columns = ['Value', 'Rank']
+		conf_df.index = conf_df.index.str.split(' (', regex=False).str[0]
+		return conf_df
+	else:
+		url = "https://kenpom.com/confstats.php"
+		if(season):
+			url = url + '?y=' + str(season)
+		browser.open(url)
+		confs = browser.get_current_page()
+		#get table
+		table = confs.find_all('table')[0]
+		conf_df = pd.read_html(str(table))[0]
+		# Clean table
+		conf_df = conf_df.set_index('Conf')
+		conf_df.columns = [stat[:-1] + 'Rank' if '.1' in stat else stat for stat in conf_df.columns]
+		return conf_df
 
 def get_standings(browser, conf, season=None):
 	"""
-	Scrapes a given conference's standing stats (https://kenpom.com) into a dataframe.
+	Scrapes a given conference's standing stats (https://kenpom.com/conf.php) into a dataframe.
 
 	Args:
 		browser (mechanicalsoul StatefulBrowser): Authenticated browser with full access to kenpom.com generated
@@ -102,12 +115,12 @@ def get_standings(browser, conf, season=None):
 	# Rename Rank headers
 	conf_df.columns = [stat[:-1] + 'Rank' if '.1' in stat else stat for stat in conf_df.columns]
 
-	print(conf_df)
 	return conf_df
+
 
 def get_offense(browser, conf, season=None):
 	"""
-	Scrapes a given conference's offense only stats (https://kenpom.com) into a dataframe.
+	Scrapes a given conference's offense only stats (https://kenpom.com/conf.php) into a dataframe.
 
 	Args:
 		browser (mechanicalsoul StatefulBrowser): Authenticated browser with full access to kenpom.com generated
@@ -131,8 +144,8 @@ def get_offense(browser, conf, season=None):
 	# Rename Rank headers
 	conf_df.columns = [stat[:-1] + 'Rank' if '.1' in stat else stat for stat in conf_df.columns]
 
-	print(conf_df)
 	return conf_df
+
 
 def get_defense(browser, conf, season=None):
 	"""
@@ -160,5 +173,4 @@ def get_defense(browser, conf, season=None):
 	# Rename Rank headers
 	conf_df.columns = [stat[:-1] + 'Rank' if '.1' in stat else stat for stat in conf_df.columns]
 
-	print(conf_df)
 	return conf_df

--- a/kenpompy/conference.py
+++ b/kenpompy/conference.py
@@ -1,0 +1,164 @@
+"""
+This module contains functions for scraping the team page kenpom.com tables into
+pandas dataframes
+"""
+
+import mechanicalsoup
+import pandas as pd
+import re
+from bs4 import BeautifulSoup
+import datetime
+
+
+def get_valid_conferences(browser, season=None):
+	"""
+	Scrapes the conferences (https://kenpom.com) into a list.
+
+	Args:
+		browser (mechanicalsoul StatefulBrowser): Authenticated browser with full access to kenpom.com generated
+			by the `login` function
+		season (str, optional): Used to define different seasons. 2002 is the earliest available season.
+
+	Returns:
+		conference_list (list): List containing all valid conferences for the given season on kenpom.com.
+	"""
+
+	url = "https://kenpom.com/conf.php"
+	url = url + '?c=B10'
+	if(season):
+		url = url + '&y=' + str(season)
+	browser.open(url)
+	confs = browser.get_current_page()
+	table = confs.find_all('table')[-1]
+	links = table.find_all('a')
+	conf_list = []
+	for link in links:
+		conf_list.append(link['href'].split('=')[-1])
+	
+	return conf_list
+
+def get_aggregate_stats(browser, conf, season=None):
+	"""
+	Scrapes a given conference's stats (https://kenpom.com) into a dataframe.
+
+	Args:
+		browser (mechanicalsoul StatefulBrowser): Authenticated browser with full access to kenpom.com generated
+			by the `login` function
+		conf (str): conference abbreviation (ie B10, P12)
+		season (str, optional): Used to define different seasons. 2002 is the earliest available season.
+
+	Returns:
+		conference_df (dataframe): Dataframe containing aggregate stats of the conference for the given season on kenpom.com.
+	"""
+
+	url = "https://kenpom.com/conf.php"
+	url = url + f'?c={conf}'
+	if(season):
+		url = url + '&y=' + str(season)
+	browser.open(url)
+	confs = browser.get_current_page()
+	#get first table
+	table = confs.find_all('table')[-3]
+	conf_df = pd.read_html(str(table))[0]
+	#get second table
+	table = confs.find_all('table')[-2]
+	conf2_df = pd.read_html(str(table))[0]
+	conf2_df['Value'] = conf2_df['Value'].str.replace('%', '').astype(float)
+	conf_df = pd.concat([conf_df, conf2_df])
+	#clean table
+	conf_df = conf_df.set_index('Stat')
+	conf_df = conf_df.drop('Unnamed: 1', axis=1)
+	conf_df.columns = ['Value', 'Rank']
+	conf_df.index = conf_df.index.str.split(' (', regex=False).str[0]
+	print(conf_df)
+	return conf_df
+
+def get_standings(browser, conf, season=None):
+	"""
+	Scrapes a given conference's standing stats (https://kenpom.com) into a dataframe.
+
+	Args:
+		browser (mechanicalsoul StatefulBrowser): Authenticated browser with full access to kenpom.com generated
+			by the `login` function
+		conf (str): conference abbreviation (ie B10, P12)
+		season (str, optional): Used to define different seasons. 2002 is the earliest available season.
+
+	Returns:
+		conference_df (dataframe): Dataframe containing standing stats of the conference for the given season on kenpom.com.
+	"""
+
+	url = "https://kenpom.com/conf.php"
+	url = url + f'?c={conf}'
+	if(season):
+		url = url + '&y=' + str(season)
+	browser.open(url)
+	confs = browser.get_current_page()
+	table = confs.find_all('table')[0]
+	conf_df = pd.read_html(str(table))[0]
+	# Parse out seed
+	conf_df['Seed'] = conf_df['Team'].str.extract('([0-9]+)')
+	conf_df['Team'] = conf_df['Team'].str.replace('([0-9]+)', '', regex=True).str.rstrip()
+
+	# Rename Rank headers
+	conf_df.columns = [stat[:-1] + 'Rank' if '.1' in stat else stat for stat in conf_df.columns]
+
+	print(conf_df)
+	return conf_df
+
+def get_offense(browser, conf, season=None):
+	"""
+	Scrapes a given conference's offense only stats (https://kenpom.com) into a dataframe.
+
+	Args:
+		browser (mechanicalsoul StatefulBrowser): Authenticated browser with full access to kenpom.com generated
+			by the `login` function
+		conf (str): conference abbreviation (ie B10, P12)
+		season (str, optional): Used to define different seasons. 2002 is the earliest available season.
+
+	Returns:
+		conference_df (dataframe): Dataframe containing offensive stats of the conference for the given season on kenpom.com.
+	"""
+
+	url = "https://kenpom.com/conf.php"
+	url = url + f'?c={conf}'
+	if(season):
+		url = url + '&y=' + str(season)
+	browser.open(url)
+	confs = browser.get_current_page()
+	table = confs.find_all('table')[1]
+	conf_df = pd.read_html(str(table))[0]
+
+	# Rename Rank headers
+	conf_df.columns = [stat[:-1] + 'Rank' if '.1' in stat else stat for stat in conf_df.columns]
+
+	print(conf_df)
+	return conf_df
+
+def get_defense(browser, conf, season=None):
+	"""
+	Scrapes a given conference's defense only stats (https://kenpom.com) into a dataframe.
+
+	Args:
+		browser (mechanicalsoul StatefulBrowser): Authenticated browser with full access to kenpom.com generated
+			by the `login` function
+		conf (str): conference abbreviation (ie B10, P12)
+		season (str, optional): Used to define different seasons. 2002 is the earliest available season.
+
+	Returns:
+		conference_df (dataframe): Dataframe containing defensive stats of the conference for the given season on kenpom.com.
+	"""
+
+	url = "https://kenpom.com/conf.php"
+	url = url + f'?c={conf}'
+	if(season):
+		url = url + '&y=' + str(season)
+	browser.open(url)
+	confs = browser.get_current_page()
+	table = confs.find_all('table')[2]
+	conf_df = pd.read_html(str(table))[0]
+
+	# Rename Rank headers
+	conf_df.columns = [stat[:-1] + 'Rank' if '.1' in stat else stat for stat in conf_df.columns]
+
+	print(conf_df)
+	return conf_df

--- a/tests/test_conference.py
+++ b/tests/test_conference.py
@@ -1,0 +1,108 @@
+import pytest
+import datetime
+import kenpompy.conference as kpconf
+import pandas as pd
+
+def test_get_valid_conferences(browser):
+	expected = 32
+
+	confs_2021 = kpconf.get_valid_conferences(browser, season = '2021')
+	assert len(confs_2021) == expected
+
+	valid_2021_confs = ['B12', 'P12', 'Pat']
+	for team in valid_2021_confs:
+		assert team in confs_2021
+
+	confs_2003 = kpconf.get_valid_conferences(browser, season = '2003')
+	assert len(confs_2003) == 32
+
+	valid_2003_confs = ['MEAC', 'CAA']
+	for team in valid_2003_confs:
+		assert team in confs_2003
+
+def test_get_aggregate_stats(browser):
+	expectedTempo = 67.9
+	expectedTempoRank = 20
+	expectedHomeWinPercent = 60.3
+	expectedHomeWinPercentRank = 8
+
+
+	confs_2021 = kpconf.get_aggregate_stats(browser, 'B10', season = '2021')
+	assert confs_2021.loc['Tempo', 'Value'] == expectedTempo
+	assert confs_2021.loc['Tempo', 'Rank'] == expectedTempoRank
+	assert confs_2021.loc['Home win%', 'Value'] == expectedHomeWinPercent
+	assert confs_2021.loc['Home win%', 'Rank'] == expectedHomeWinPercentRank
+	
+
+
+
+	expectedTempo = 65.5
+	expectedTempoRank = 27
+	expectedHomeWinPercent = 71.6
+	expectedHomeWinPercentRank = 2
+
+	confs_2003 = kpconf.get_aggregate_stats(browser, 'B10', season = '2003')
+	assert confs_2003.loc['Tempo', 'Value'] == expectedTempo
+	assert confs_2003.loc['Tempo', 'Rank'] == expectedTempoRank
+	assert confs_2003.loc['Home win%', 'Value'] == expectedHomeWinPercent
+	assert confs_2003.loc['Home win%', 'Rank'] == expectedHomeWinPercentRank
+
+def test_get_standings(browser):
+	expectedTeam1 = 'Michigan'
+	expectedTeam1AdjO = 117.6
+	expectedTeam1AdjORank = 9
+	
+	confs_2021 = kpconf.get_standings(browser, 'B10', season = '2021')
+	assert confs_2021.iloc[0, :]['Team'] == expectedTeam1
+	assert confs_2021.iloc[0, :]['AdjO'] == expectedTeam1AdjO
+	assert confs_2021.iloc[0, :]['AdjO.Rank'] == expectedTeam1AdjORank
+
+	
+	expectedTeam1 = 'Wisconsin'
+	expectedTeam1AdjO = 114.4
+	expectedTeam1AdjORank = 16	
+
+	confs_2003 = kpconf.get_standings(browser, 'B10', season = '2003')
+	assert confs_2003.iloc[0, :]['Team'] == expectedTeam1
+	assert confs_2003.iloc[0, :]['AdjO'] == expectedTeam1AdjO
+	assert confs_2003.iloc[0, :]['AdjO.Rank'] == expectedTeam1AdjORank
+
+def test_get_offense(browser):
+	expectedTeam1 = 'Iowa'
+	expectedTeam1Tempo = 69
+	expectedTeam1TempoRank = 4
+	
+	confs_2021 = kpconf.get_offense(browser, 'B10', season = '2021')
+	assert confs_2021.iloc[0, :]['Team'] == expectedTeam1
+	assert confs_2021.iloc[0, :]['Tempo'] == expectedTeam1Tempo
+	assert confs_2021.iloc[0, :]['Tempo.Rank'] == expectedTeam1TempoRank
+
+	
+	expectedTeam1 = 'Wisconsin'
+	expectedTeam1Tempo = 61.5
+	expectedTeam1TempoRank = 11	
+
+	confs_2003 = kpconf.get_offense(browser, 'B10', season = '2003')
+	assert confs_2003.iloc[0, :]['Team'] == expectedTeam1
+	assert confs_2003.iloc[0, :]['Tempo'] == expectedTeam1Tempo
+	assert confs_2003.iloc[0, :]['Tempo.Rank'] == expectedTeam1TempoRank
+
+def test_get_defense(browser):
+	expectedTeam1 = 'Michigan'
+	expectedTeam1Stl = 6.4
+	expectedTeam1StlRank = 12
+	
+	confs_2021 = kpconf.get_defense(browser, 'B10', season = '2021')
+	assert confs_2021.iloc[0, :]['Team'] == expectedTeam1
+	assert confs_2021.iloc[0, :]['Stl%'] == expectedTeam1Stl
+	assert confs_2021.iloc[0, :]['Stl%.Rank'] == expectedTeam1StlRank
+
+
+	expectedTeam1 = 'Illinois'
+	expectedTeam1Stl = 9.7
+	expectedTeam1StlRank = 6
+
+	confs_2003 = kpconf.get_defense(browser, 'B10', season = '2003')
+	assert confs_2003.iloc[0, :]['Team'] == expectedTeam1
+	assert confs_2003.iloc[0, :]['Stl%'] == expectedTeam1Stl
+	assert confs_2003.iloc[0, :]['Stl%.Rank'] == expectedTeam1StlRank

--- a/tests/test_conference.py
+++ b/tests/test_conference.py
@@ -12,6 +12,8 @@ def test_get_valid_conferences(browser):
 	valid_2021_confs = ['B12', 'P12', 'Pat']
 	for team in valid_2021_confs:
 		assert team in confs_2021
+	assert confs_2021[0] == 'A10'
+	assert confs_2021[-1] == 'WCC'
 
 	confs_2003 = kpconf.get_valid_conferences(browser, season = '2003')
 	assert len(confs_2003) == 32
@@ -19,6 +21,9 @@ def test_get_valid_conferences(browser):
 	valid_2003_confs = ['MEAC', 'CAA']
 	for team in valid_2003_confs:
 		assert team in confs_2003
+	assert confs_2003[0] == 'A10'
+	assert confs_2003[-1] == 'ind'
+
 
 def test_get_aggregate_stats(browser):
 	expectedTempo = 67.9
@@ -26,16 +31,12 @@ def test_get_aggregate_stats(browser):
 	expectedHomeWinPercent = 60.3
 	expectedHomeWinPercentRank = 8
 
-
 	confs_2021 = kpconf.get_aggregate_stats(browser, 'B10', season = '2021')
 	assert confs_2021.loc['Tempo', 'Value'] == expectedTempo
 	assert confs_2021.loc['Tempo', 'Rank'] == expectedTempoRank
 	assert confs_2021.loc['Home win%', 'Value'] == expectedHomeWinPercent
 	assert confs_2021.loc['Home win%', 'Rank'] == expectedHomeWinPercentRank
 	
-
-
-
 	expectedTempo = 65.5
 	expectedTempoRank = 27
 	expectedHomeWinPercent = 71.6
@@ -47,6 +48,21 @@ def test_get_aggregate_stats(browser):
 	assert confs_2003.loc['Home win%', 'Value'] == expectedHomeWinPercent
 	assert confs_2003.loc['Home win%', 'Rank'] == expectedHomeWinPercentRank
 
+	expectedTempo = 67
+	expectedTempoRank = 28
+
+	confs_2021 = kpconf.get_aggregate_stats(browser, season = '2021')
+	assert confs_2021.loc['AE', 'Tempo'] == expectedTempo
+	assert confs_2021.loc['AE', 'Tempo.Rank'] == expectedTempoRank
+
+	expectedTempo = 67.2
+	expectedTempoRank = 20
+
+	confs_2003 = kpconf.get_aggregate_stats(browser, season = '2003')
+	assert confs_2003.loc['AE', 'Tempo'] == expectedTempo
+	assert confs_2003.loc['AE', 'Tempo.Rank'] == expectedTempoRank
+
+
 def test_get_standings(browser):
 	expectedTeam1 = 'Michigan'
 	expectedTeam1AdjO = 117.6
@@ -57,7 +73,6 @@ def test_get_standings(browser):
 	assert confs_2021.iloc[0, :]['AdjO'] == expectedTeam1AdjO
 	assert confs_2021.iloc[0, :]['AdjO.Rank'] == expectedTeam1AdjORank
 
-	
 	expectedTeam1 = 'Wisconsin'
 	expectedTeam1AdjO = 114.4
 	expectedTeam1AdjORank = 16	
@@ -66,6 +81,7 @@ def test_get_standings(browser):
 	assert confs_2003.iloc[0, :]['Team'] == expectedTeam1
 	assert confs_2003.iloc[0, :]['AdjO'] == expectedTeam1AdjO
 	assert confs_2003.iloc[0, :]['AdjO.Rank'] == expectedTeam1AdjORank
+
 
 def test_get_offense(browser):
 	expectedTeam1 = 'Iowa'
@@ -77,7 +93,6 @@ def test_get_offense(browser):
 	assert confs_2021.iloc[0, :]['Tempo'] == expectedTeam1Tempo
 	assert confs_2021.iloc[0, :]['Tempo.Rank'] == expectedTeam1TempoRank
 
-	
 	expectedTeam1 = 'Wisconsin'
 	expectedTeam1Tempo = 61.5
 	expectedTeam1TempoRank = 11	
@@ -86,6 +101,7 @@ def test_get_offense(browser):
 	assert confs_2003.iloc[0, :]['Team'] == expectedTeam1
 	assert confs_2003.iloc[0, :]['Tempo'] == expectedTeam1Tempo
 	assert confs_2003.iloc[0, :]['Tempo.Rank'] == expectedTeam1TempoRank
+
 
 def test_get_defense(browser):
 	expectedTeam1 = 'Michigan'
@@ -96,7 +112,6 @@ def test_get_defense(browser):
 	assert confs_2021.iloc[0, :]['Team'] == expectedTeam1
 	assert confs_2021.iloc[0, :]['Stl%'] == expectedTeam1Stl
 	assert confs_2021.iloc[0, :]['Stl%.Rank'] == expectedTeam1StlRank
-
 
 	expectedTeam1 = 'Illinois'
 	expectedTeam1Stl = 9.7


### PR DESCRIPTION
I have implemented pulling stats by conferences. They're pulled from this [url](https://kenpom.com/conf.php?c=B10). 

It currently pulls:
- Conference ids for a given season
- Aggregate stats for the whole conference
- Standing stats
- Offense stats
- Defense stats

Let me know if there are any changes/additions for the conferences page.
Logan