### PR TITLE
Fixed shape test for test_get_program_ratings after patch to remove extraneous rows

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -78,7 +78,7 @@ def test_get_gameattribs(browser):
 
 
 def test_get_program_ratings(browser):
-	expected = (358, 17)
+	expected = (356, 17)
 
 	df = kpmisc.get_program_ratings(browser)
 	assert df.shape == expected


### PR DESCRIPTION
The test broke in the last push to `master`. Not sure how this slipped by my numerous tests and CI/CD, but updating to expect 356 rows in accordance with what displays on the [target page](https://kenpom.com/programs.php).