### PR TITLE
"Miscellaneous Team Stats" scraping

### DIFF
--- a/kenpompy/teamstats.py
+++ b/kenpompy/teamstats.py
@@ -1,0 +1,47 @@
+"""
+This module contains functions for scraping the team stats page table into
+pandas dataframes
+"""
+
+import pandas as pd
+import datetime
+import re
+
+def get_team_stats(browser, season=None, defense=False):
+	"""
+	Scrapes the team-level statistics (https://kenpom.com/teamstats.php) into a DataFrame.
+
+	Args:
+		browser (mechanicalsoup StatefulBrowser): Authenticated browser with full access to kenpom.com generated
+			by the `login` function
+		season (str, optional): Used to define different seasons. 2001 is the earliest available season.
+		defense (bool): Whether to return defensive stats instead of the default offensive
+
+	Returns:
+		teamstats_df (pandas dataframe): A dataframe representation of the requested season's stats
+	"""
+	if season:
+		if int(season) < 2002:
+			raise ValueError(
+				'season cannot be less than 2002, as data only goes back that far.')
+		if int(season) > int(datetime.date.today().strftime("%Y")):
+			raise ValueError(
+				'season cannot be greater than the current year.')
+
+	url = "https://kenpom.com/teamstats.php?y=" + str(season or '')
+	if defense:
+		url = url + '&od=d'
+		
+	browser.open(url)
+	teamstats = browser.get_current_page()
+	table = teamstats.find('table')
+	teamstats_df = pd.read_html(str(table), header=0)[0]
+	teamstats_df = teamstats_df[teamstats_df["Team"] != "Team"]
+	teamstats_df.columns = teamstats_df.columns.str.replace(r'\.1$', '.Rank', regex=True)
+	teamstats_df.reset_index(drop=True, inplace=True)
+	
+	# Parse NCAA tournament seed from Team name
+	teamstats_df[['Team', 'Seed']] = teamstats_df['Team'].str.extract(r'^(?P<Team>[A-Za-z\s]+)(?:\s?(?P<Rank>\d{1,2}))?', expand=True)
+	teamstats_df['Team'] = teamstats_df['Team'].str.strip()
+
+	return teamstats_df

--- a/tests/test_teamstats.py
+++ b/tests/test_teamstats.py
@@ -5,7 +5,7 @@ def test_get_team_stats(browser):
     team_stats_2022 = get_team_stats(browser, season=2022)
     assert team_stats_2022.shape == (358, 21)
     expected = ['Villanova', 'BE', '35.9', '57', '49.5', '187', '83.0', '1', '11.2', '323', '7.4', '22', '8.1', '83', '48.9', '227', '46.3', '17', '117.5', '9', '2']
-    assert team_stats_2022.iloc[56] == expected
+    assert team_stats_2022.iloc[56].to_list() == expected
 
     team_stats_2022 = get_team_stats(browser, season=2022, defense=True)
     assert team_stats_2022.shape == (358, 21)

--- a/tests/test_teamstats.py
+++ b/tests/test_teamstats.py
@@ -1,0 +1,13 @@
+import pytest
+from kenpompy.teamstats import get_team_stats
+
+def test_get_team_stats(browser):
+    team_stats_2022 = get_team_stats(browser, season=2022)
+    assert team_stats_2022.shape == (358, 21)
+    expected = ['Villanova', 'BE', '35.9', '57', '49.5', '187', '83.0', '1', '11.2', '323', '7.4', '22', '8.1', '83', '48.9', '227', '46.3', '17', '117.5', '9', '2']
+    assert team_stats_2022.iloc[56] == expected
+
+    team_stats_2022 = get_team_stats(browser, season=2022, defense=True)
+    assert team_stats_2022.shape == (358, 21)
+    expected = ['Villanova', 'BE', '30.8', '40', '48.1', '114', '73.4', '276', '6.9', '277', '9.4', '159', '9.0', '186', '49.9', '149', '42.2', '308', '92.9', '23', '2']
+    assert team_stats_2022.iloc[39].to_list() == expected


### PR DESCRIPTION
New simplistic feature for scraping KenPom's [Miscellaneous Team Stats pages](https://kenpom.com/teamstats.php).

Includes all the standard stuff: season support, offense/defense stats scraping support, support for parsing NCAA seeds when present on the page, plus the test cases to boot.