### PR TITLE
Update to test_get_program_ratings to use dynamic verification of df shape

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -78,7 +78,6 @@ def test_get_gameattribs(browser):
 
 
 def test_get_program_ratings(browser):
-	expected = (356, 17)
-
 	df = kpmisc.get_program_ratings(browser)
+	expected = (len(browser.page.select("tr:not(:has(th))")), 17)
 	assert df.shape == expected


### PR DESCRIPTION
Ensures we don't have to update the tuple literal annually by instead performing the verification based on the number of table rows `bs4` returns. This way, the test still ensures that the logic applied for casting the program ratings table to a `DataFrame` doesn't include/exclude anything erroneous.