### PR TITLE
CI/CD updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 name: Python package
-
 on: [push]
+concurrency:
+  group: ${{ github.repository }}
+  cancel-in-progress: true
 
 jobs:
   pytest:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,12 @@
 name: Python package
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
 concurrency:
   group: ${{ github.repository }}
   cancel-in-progress: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 1
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
* Adds Python 3.12 to the platform matrix (#57)
* Limits CI/CD runs on all branches other than `master` to be triggered only when a pull request is created
* Configures [`concurrency`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) to prevent multiple jobs in the repository from running simultaneously, where newer runs would break older runs because of the way KenPom's authentication permits only one active session per account at a time