### PR TITLE
Remove cancel-in-progress from CI/CD concurrency config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ on:
 
 concurrency:
   group: ${{ github.repository }}
-  cancel-in-progress: true
 
 jobs:
   pytest:


### PR DESCRIPTION
Got a little overzealous in #58 - better option is instead to remove this option and allow the jobs to queue up instead of being arbitrarily cancelled