### PR TITLE
Add name parsing tests for previously problematic team names

### DIFF
--- a/tests/test_conference.py
+++ b/tests/test_conference.py
@@ -121,3 +121,6 @@ def test_get_defense(browser):
 	assert confs_2003.iloc[0, :]['Team'] == expectedTeam1
 	assert confs_2003.iloc[0, :]['Stl%'] == expectedTeam1Stl
 	assert confs_2003.iloc[0, :]['Stl%.Rank'] == expectedTeam1StlRank
+
+	confs_2021 = kpconf.get_defense(browser, 'BW', season = '2021')
+	assert confs_2021.loc[5]['Team'] == 'Cal St. Bakersfield'

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -8,6 +8,9 @@ def test_get_pomeroy_ratings(browser):
     df = kpmisc.get_pomeroy_ratings(browser, season=2019)
     assert df.iloc[0].to_list() == expected
 
+    expected = ['253', 'Cal St. Northridge', 'BW', '13-21', '-7.74', '104.8', '170', '112.5', '318', '70.9', '43', '-.018', '232', '-4.63', '263', '101.7', '282', '106.3', '225', '-4.09', '279', '']
+    assert df.loc[252].to_list() == expected
+
     # Also test proper handling of team names with special characters like ' and &
     expected = ['31', "Saint Mary's", 'WCC', '22-12', '+17.31', '114.7', '23', '97.4', '55', '62.7', '348', '-.045', '285', '+3.66', '82', '106.6', '76', '103.0', '100', '-0.90', '183', '11']
     assert df.iloc[30].to_list() == expected

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -8,6 +8,7 @@ def test_get_efficiency(browser):
 
 	df = kpsum.get_efficiency(browser, season = '2019')
 	assert [str(i) for i in df[df.Team == 'Louisville'].iloc[0].to_list()] == expected
+	assert df.loc[44]['Team'] == 'Cal St. Northridge'
 
 	expected = ['Louisville', 'BE', '65.3', '160', '67.1', '169', '113.1', '40', '107.3', '67', '87.7', '4', '91.2', 
 				'7']

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -9,7 +9,7 @@ def test_get_valid_teams(browser):
 	teams_2021 = kpteam.get_valid_teams(browser, season = '2021')
 	assert len(teams_2021) == expected
 
-	valid_2021_teams = ['Gonzaga', 'Penn St.', 'Florida', 'Xavier', 'VMI', 'Kennesaw St.', 'Wagner', 'Bucknell', 'Maryland Eastern Shore']
+	valid_2021_teams = ['Gonzaga', 'Penn St.', 'Florida', 'Xavier', 'VMI', 'Kennesaw St.', 'Wagner', 'Bucknell', 'Maryland Eastern Shore', 'Cal St. Fullerton']
 	for team in valid_2021_teams:
 		assert team in teams_2021
 


### PR DESCRIPTION
Closes #66 by adding assertions in most test files to check that the parsing of team names is functioning as intended, using `Cal St. *` schools as testers.

I'm going to review my own work with fresher eyes tomorrow and try to locate some more examples of names that were previously not parsed correctly and add some where necessary.