### PR TITLE
Fixed team schedules before 2010

### DIFF
--- a/kenpompy/team.py
+++ b/kenpompy/team.py
@@ -88,11 +88,14 @@ def get_schedule(browser, team=None, season=None):
 
 	# Dataframe Tidying
 	schedule_df = schedule_df[0]
+	# Teams 2010 and earlier do not show their team rank, add column for consistency
+	if(len(schedule_df.columns) == 10):
+		schedule_df.insert(1, 'Team Rank', '')
 	schedule_df.columns = ['Date', 'Team Rank', 'Opponent Rank', 'Opponent Name', 'Result', 'Possession Number',
 					  'A', 'Location', 'Record', 'Conference', 'B']
 	schedule_df = schedule_df.drop(columns = ['A', 'B'])
 	schedule_df = schedule_df.fillna('')
-	schedule_df = schedule_df[schedule_df['Date'] != schedule_df['Team Rank']]
+	schedule_df = schedule_df[schedule_df['Date'] != schedule_df['Result']]
 	schedule_df = schedule_df[schedule_df['Date'] != 'Date']
 
 	return schedule_df

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -56,6 +56,14 @@ def test_get_schedule(browser):
 	with pytest.raises(ValueError):
 		kpteam.get_schedule(browser, team='Incorrect Team Name', season=2017)
 
+	centenary_expected = ['Sat Nov 11', '', '172', 'TCU', 'L, 72-66', '76', 'Away', '0-1', '']
+	centenary_df = kpteam.get_schedule(browser, team='Centenary', season=2007)
+	assert [str(i) for i in centenary_df[centenary_df.Date == 'Sat Nov 11'].iloc[0].to_list()] == centenary_expected
+	assert centenary_df.shape == (31, 9)
+
+	with pytest.raises(ValueError):
+		kpteam.get_schedule(browser, team='Centenary', season=2017)
+
 	# Make sure that the valid team check is triggered
 	with pytest.raises(ValueError):
 		kpteam.get_schedule(browser, season = '2013', team="LMU")

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -50,6 +50,12 @@ def test_get_schedule(browser):
 	with pytest.raises(ValueError):
 		kpteam.get_schedule(browser, season = "2009")
 
+	with pytest.raises(ValueError):
+		kpteam.get_schedule(browser, team='Merrimack', season=2019)
+
+	with pytest.raises(ValueError):
+		kpteam.get_schedule(browser, team='Incorrect Team Name', season=2017)
+
 	# Make sure that the valid team check is triggered
 	with pytest.raises(ValueError):
 		kpteam.get_schedule(browser, season = '2013', team="LMU")


### PR DESCRIPTION
Originally was looking into #68, but seems to all ready be handled after creating tests. It is handled by this code:
https://github.com/j-andrews7/kenpompy/blob/a30590ba57cfb004ac1bbad3b27099f4b9110906/kenpompy/team.py#L74-L77

However, I found an issue with team's schedules not having a rank column 2010 and earlier. Added logic to handle the missing column.

test_team.py test coverage now includes:
- Teams with no data for a given year
- Incorrect team names
- Team's schedule 2010 and before