### PR TITLE
add NST% columns

### DIFF
--- a/kenpompy/summary.py
+++ b/kenpompy/summary.py
@@ -155,9 +155,10 @@ def get_teamstats(browser, defense=False, season=None):
 
 	# Dataframe tidying.
 	ts_df = ts_df[0]
-	ts_df = ts_df.iloc[:, 0:18]
+	print(ts_df.columns)
+	ts_df = ts_df.iloc[:, 0:20]
 	ts_df.columns = ['Team', 'Conference', '3P%', '3P%.Rank', '2P%', '2P%.Rank', 'FT%', 'FT%.Rank',
-					 'Blk%', 'Blk%.Rank', 'Stl%', 'Stl%.Rank', 'A%', 'A%.Rank', '3PA%', '3PA%.Rank',
+					 'Blk%', 'Blk%.Rank', 'Stl%', 'Stl%.Rank', 'NST%', 'NST%.Rank', 'A%', 'A%.Rank', '3PA%', '3PA%.Rank',
 					 last_cols[0], last_cols[1]]
 
 	# Remove the header rows that are interjected for readability.

--- a/kenpompy/summary.py
+++ b/kenpompy/summary.py
@@ -155,7 +155,6 @@ def get_teamstats(browser, defense=False, season=None):
 
 	# Dataframe tidying.
 	ts_df = ts_df[0]
-	print(ts_df.columns)
 	ts_df = ts_df.iloc[:, 0:20]
 	ts_df.columns = ['Team', 'Conference', '3P%', '3P%.Rank', '2P%', '2P%.Rank', 'FT%', 'FT%.Rank',
 					 'Blk%', 'Blk%.Rank', 'Stl%', 'Stl%.Rank', 'NST%', 'NST%.Rank', 'A%', 'A%.Rank', '3PA%', '3PA%.Rank',


### PR DESCRIPTION
New column mapping for ```get_teamstats()```. Added missing NST% and NST% Rank

Before, A% and 3PA% were getting populated with the wrong values, and AdjOE values would not be present.


![image](https://github.com/j-andrews7/kenpompy/assets/3138933/f46a2a30-b13f-4bfc-8c04-7e6ad6f1880a)
