### PR TITLE
Handle dates with no games in fanmatch data

### DIFF
--- a/tests/test_fanmatch.py
+++ b/tests/test_fanmatch.py
@@ -55,3 +55,13 @@ def test_fanmatch(browser):
 	fm = FanMatch(browser, date)
 	assert fm.fm_df.Tournament.loc[0] == "NCAA"
 	assert "NCAA" not in fm.fm_df.Game.loc[0]
+
+    # Test for a day with no game that is in season
+	date = "2020-12-24"
+	fm = FanMatch(browser, date)
+	assert fm.fm_df is None
+
+    # Test for a day with no games that is during the offseason
+	date = "2024-10-30"
+	fm = FanMatch(browser, date)
+	assert fm.fm_df is None


### PR DESCRIPTION
Adds checks for fanmatch to handle dates with no games and add two test cases for these changes. Handles #92.